### PR TITLE
Fix makefile not downloading model

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ all: downloadModels caffe.sif
 downloadModels: 
 	[ -e bvlc_googlenet ] || mkdir -p bvlc_googlenet
 	[ -e bvlc_googlenet/deploy.prototxt ] || wget https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_googlenet/deploy.prototxt -O bvlc_googlenet/deploy.prototxt
-	[ -ebvlc_googlenet/bvlc_googlenet.caffemodel ] || wget http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel -O bvlc_googlenet/bvlc_googlenet.caffemodel
+	[ -e bvlc_googlenet/bvlc_googlenet.caffemodel ] || wget http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel -O bvlc_googlenet/bvlc_googlenet.caffemodel
 	
 caffe.sif: environment.def
 	sudo singularity build caffe.sif environment.def


### PR DESCRIPTION
Missing space in bash statement caused make to not download the model file like it should.